### PR TITLE
Update date input type value on edit

### DIFF
--- a/templates/app/helpers.js
+++ b/templates/app/helpers.js
@@ -10,7 +10,8 @@ var getMessage = function(error) {
 module.exports = function(app) {
     app.locals({
         errorFor : function(model, property) {
-            var modelToValidate = this[model];
+            // updated passing model reference directly since below lookup failed
+            var modelToValidate = model; //this[model];
 
             if (modelToValidate && modelToValidate.errors) {
                 if (property && modelToValidate.errors[property]) {

--- a/templates/app/helpers.js
+++ b/templates/app/helpers.js
@@ -33,6 +33,20 @@ module.exports = function(app) {
             }
 
             return value;
+        },
+        
+       dateAsValue : function(date) {
+            // check if this is a date 
+            if(util.isDate(date)){
+                // if so we can format it to RFC3339 specification, 'yyyy-mm-dd'
+                var day = date.getDate();
+                var month = date.getMonth() + 1; //Months are zero based
+                var year = date.getFullYear();
+                return year + '-' + (month < 10 ? '0'+month: month) + '-' + day; 
+            }
+            // otherwise add some logging to inform dev
+            console.log('Non Date object passed as a value for the dateAsValue function in helper')
+            return date;
         }
     });
 };

--- a/templates/app/views/mixins/form-helpers.jade
+++ b/templates/app/views/mixins/form-helpers.jade
@@ -23,5 +23,9 @@ mixin datetime(field, value)
   input.span2(type="datetime", id=field, name=field, value=value)
 
     
-mixin errorMessage(model, field)
+mixin errorMessage(model, field, group)
   !{errorFor(model, field)}
+  //- some extra marking using bootstrap error class on optional control group element
+  if( group && model.errors && model.errors[field] )
+    script
+      $('##{group}').addClass('error');

--- a/templates/app/views/mixins/form-helpers.jade
+++ b/templates/app/views/mixins/form-helpers.jade
@@ -17,7 +17,7 @@ mixin boolean(field, value)
   input.span1(type="checkbox", id=field, name=field, checked=value)
 
 mixin date(field, value)
-  input.span2(type="date", id=field, name=field, value=value)
+  input.span2(type="date", id=field, name=field, value=dateAsValue(value))
 
 mixin datetime(field, value)
   input.span2(type="datetime", id=field, name=field, value=value)

--- a/templates/scaffold/views/create.jade.ejs
+++ b/templates/scaffold/views/create.jade.ejs
@@ -30,7 +30,7 @@ block content
 <%    } else { -%>
           | <%= properties[i].type %>
 <%    } -%>
-          mixin errorMessage('<%=model.singular%>', '<%=properties[i].name%>')
+          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>')
 <% } -%>
 
     .form-actions

--- a/templates/scaffold/views/create.jade.ejs
+++ b/templates/scaffold/views/create.jade.ejs
@@ -8,7 +8,7 @@ block content
       legend Create a new <%=model.singularCapitalized%>
     
 <% for(var i in properties) { -%>
-      .control-group
+      .control-group#group-<%= properties[i].name %>
         mixin label("<%= properties[i].name %>", "<%= properties[i].nameCapitalized %>")        
         .controls
 <%    if(properties[i].type === 'String') { -%>
@@ -30,7 +30,7 @@ block content
 <%    } else { -%>
           | <%= properties[i].type %>
 <%    } -%>
-          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>')
+          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>', 'group-<%= properties[i].name %>')
 <% } -%>
 
     .form-actions

--- a/templates/scaffold/views/edit.jade.ejs
+++ b/templates/scaffold/views/edit.jade.ejs
@@ -7,7 +7,7 @@ block content
       legend Edit <%=model.singularCapitalized%>
 
 <% for(var i in properties) { -%>
-      .control-group
+      .control-group#group-<%= properties[i].name %>
         mixin label("<%= properties[i].name %>", "<%= properties[i].nameCapitalized %>")        
         .controls
 <%    if(properties[i].type === 'String') { -%>
@@ -29,7 +29,7 @@ block content
 <%    } else { -%>
           | <%= properties[i].type %>
 <%    } -%>
-          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>')
+          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>', 'group-<%= properties[i].name %>')
 <% } -%>
 
     .form-actions

--- a/templates/scaffold/views/edit.jade.ejs
+++ b/templates/scaffold/views/edit.jade.ejs
@@ -29,7 +29,7 @@ block content
 <%    } else { -%>
           | <%= properties[i].type %>
 <%    } -%>
-          mixin errorMessage('<%=model.singular%>', '<%=properties[i].name%>')
+          mixin errorMessage(<%=model.singular%>, '<%=properties[i].name%>')
 <% } -%>
 
     .form-actions


### PR DESCRIPTION
Editing objects with chrome failed because of the date format used on the value attribute of the input of type date. Needed to match rfc3339 spec so I created a helper function that does exactly that. 

I didn't change anything for the datetime type since I don't have proper input type rendering on chrome here. Might be possible to do the same on a browser that does support datetime input types.
